### PR TITLE
Show friendly representation of related fields

### DIFF
--- a/rijkshuisstijl/templatetags/rijkshuisstijl_helpers.py
+++ b/rijkshuisstijl/templatetags/rijkshuisstijl_helpers.py
@@ -147,18 +147,4 @@ def get_recursed_field_value(obj, field):
         field = fields.pop(0)
         obj = getattr(obj, field)
 
-    field_name = fields[0]
-    value = getattr(obj, fields[0])
-
-    if field_name.endswith("_set"):
-        related_name = field_name.replace("_set", "")
-        related_object_names = [
-            related_field.name for related_field in obj._meta.related_objects
-        ]
-
-        # double check if the field_name is actually a reverse relation
-        # and not just a name which ends with "_set"
-        if related_name in related_object_names:
-            return ", ".join([str(instance) for instance in value.all()])
-
-    return value
+    return getattr(obj, fields[0])

--- a/rijkshuisstijl/templatetags/rijkshuisstijl_helpers.py
+++ b/rijkshuisstijl/templatetags/rijkshuisstijl_helpers.py
@@ -146,4 +146,19 @@ def get_recursed_field_value(obj, field):
     while len(fields) > 1:
         field = fields.pop(0)
         obj = getattr(obj, field)
-    return getattr(obj, fields[0])
+
+    field_name = fields[0]
+    value = getattr(obj, fields[0])
+
+    if field_name.endswith("_set"):
+        related_name = field_name.replace("_set", "")
+        related_object_names = [
+            related_field.name for related_field in obj._meta.related_objects
+        ]
+
+        # double check if the field_name is actually a reverse relation
+        # and not just a name which ends with "_set"
+        if related_name in related_object_names:
+            return ", ".join([str(instance) for instance in value.all()])
+
+    return value

--- a/rijkshuisstijl/templatetags/rijkshuisstijl_helpers.py
+++ b/rijkshuisstijl/templatetags/rijkshuisstijl_helpers.py
@@ -146,5 +146,4 @@ def get_recursed_field_value(obj, field):
     while len(fields) > 1:
         field = fields.pop(0)
         obj = getattr(obj, field)
-
     return getattr(obj, fields[0])

--- a/rijkshuisstijl/templatetags/rijkshuisstijl_utils.py
+++ b/rijkshuisstijl/templatetags/rijkshuisstijl_utils.py
@@ -50,14 +50,16 @@ def format_value(obj, field):
     # Check for (related) value.
     val = get_recursed_field_value(obj, field)
 
+    # In case the field is a related manager, return a comma seperated
+    # string with the string representation of each instance.
     if field.endswith("_set"):
         related_name = field.replace("_set", "")
         related_object_names = [
             related_field.name for related_field in obj._meta.related_objects
         ]
 
-        # double check if the field_name is actually a reverse relation
-        # and not just a name which ends with "_set"
+        # Double check if the field_name is actually a reverse relation
+        # and not just a name which ends with "_set".
         if related_name in related_object_names:
             return ", ".join([str(instance) for instance in val.all()])
 

--- a/rijkshuisstijl/templatetags/rijkshuisstijl_utils.py
+++ b/rijkshuisstijl/templatetags/rijkshuisstijl_utils.py
@@ -49,6 +49,18 @@ def format_value(obj, field):
 
     # Check for (related) value.
     val = get_recursed_field_value(obj, field)
+
+    if field.endswith("_set"):
+        related_name = field.replace("_set", "")
+        related_object_names = [
+            related_field.name for related_field in obj._meta.related_objects
+        ]
+
+        # double check if the field_name is actually a reverse relation
+        # and not just a name which ends with "_set"
+        if related_name in related_object_names:
+            return ", ".join([str(instance) for instance in val.all()])
+
     if val:
         try:
             # Try to apply date formatting.

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from rijkshuisstijl.views.generic import CreateView, DetailView, ListView, UpdateView, TemplateView
-from tests.models import Book
+from tests.models import Book, Publisher
 
 app_name = "test"
 fields = ("title", "authors", "publisher", "date_published", "stock")
@@ -12,4 +12,11 @@ urlpatterns = [
     path("<int:pk>", DetailView.as_view(model=Book, fields=fields), name="detail"),
     path("", ListView.as_view(model=Book, fields=fields, paginate_by=2), name="list"),
     path("<int:pk>/update", UpdateView.as_view(model=Book, fields=fields), name="update"),
+    path(
+        "/publisher/<int:pk>",
+        DetailView.as_view(
+            model=Publisher, fields=("name", "book_set",)
+        ),
+        name="publisher-detail"
+    ),
 ]


### PR DESCRIPTION
The `get_recursed_field_value` currently returns the field value as is. This causes related fields to return the string representation of a related manager object. This PR returns the string representation of all instances available in the related manager.