### PR TITLE
Set form attribute on submit button when form id is given

### DIFF
--- a/rijkshuisstijl/templates/rijkshuisstijl/components/button/button.html
+++ b/rijkshuisstijl/templates/rijkshuisstijl/components/button/button.html
@@ -27,7 +27,8 @@
             {% if disabled %} disabled{% endif %}
             {% if focus_target %} data-focus-target="{{ focus_target }}"{% endif %}
             {% if toggle_target %} data-toggle-target="{{ toggle_target }}" data-toggle-modifier="{{ toggle_modifier }}"{% endif %}
-            {% if toggle_mobile_state %}data-toggle-mobile-state="{{ toggle_mobile_state }}"{% endif %}>
+            {% if toggle_mobile_state %}data-toggle-mobile-state="{{ toggle_mobile_state }}"{% endif %}
+            {% if form %}form="{{ form }}"{% endif %}>
 
         {% include 'rijkshuisstijl/components/button/label.html' with class=class label=label icon=icon icon_src=icon_src only %}
     </button>

--- a/rijkshuisstijl/templates/rijkshuisstijl/components/form/actions.html
+++ b/rijkshuisstijl/templates/rijkshuisstijl/components/form/actions.html
@@ -1,5 +1,5 @@
 {% load rijkshuisstijl %}{% spaceless %}
     <div class="form__actions{% if align %} form__actions--{{ align }}{% endif %}">
-        {% button class=button_class|default:'button--primary' label=label|default:_('Verzenden') type='submit' form=form %}
+        {% button class=button_class|default:'button--primary' label=label|default:_('Verzenden') type='submit' form=form_id %}
     </div>
 {% endspaceless %}

--- a/rijkshuisstijl/templates/rijkshuisstijl/components/form/actions.html
+++ b/rijkshuisstijl/templates/rijkshuisstijl/components/form/actions.html
@@ -1,5 +1,5 @@
 {% load rijkshuisstijl %}{% spaceless %}
     <div class="form__actions{% if align %} form__actions--{{ align }}{% endif %}">
-        {% button class=button_class|default:'button--primary' label=label|default:_('Verzenden') type='submit' %}
+        {% button class=button_class|default:'button--primary' label=label|default:_('Verzenden') type='submit' form=form %}
     </div>
 {% endspaceless %}

--- a/rijkshuisstijl/templates/rijkshuisstijl/components/form/form.html
+++ b/rijkshuisstijl/templates/rijkshuisstijl/components/form/form.html
@@ -25,7 +25,7 @@
                     {# First fieldset gets actions appended to it if actions_postion equals top or both. #}
                     {% if forloop.first and actions_position in 'top,both' %}
                         <div class="form__body form__body--transparent">
-                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label %}
+                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form=id %}
                         </div>
                         <br>
                     {% endif %}
@@ -44,7 +44,7 @@
 
                         {# Last fieldset gets actions appended to it if actions_postion equals bottom. #}
                         {% if forloop.last and actions_position == 'auto' %}
-                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label %}
+                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form=id %}
                         {% endif %}
                     </fieldset>
 
@@ -52,7 +52,7 @@
                     {% if forloop.last and actions_position in 'bottom,both' %}
                         <br>
                         <div class="form__body">
-                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label %}
+                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form=id %}
                         </div>
                     {% endif %}
                 {% endfor %}
@@ -63,7 +63,7 @@
                         {% form_field field %}
                     {% endfor %}
 
-                    {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label %}
+                    {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form=id %}
                 </fieldset>
             {% endif %}
         </div>

--- a/rijkshuisstijl/templates/rijkshuisstijl/components/form/form.html
+++ b/rijkshuisstijl/templates/rijkshuisstijl/components/form/form.html
@@ -25,7 +25,7 @@
                     {# First fieldset gets actions appended to it if actions_postion equals top or both. #}
                     {% if forloop.first and actions_position in 'top,both' %}
                         <div class="form__body form__body--transparent">
-                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form=id %}
+                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form_id=id %}
                         </div>
                         <br>
                     {% endif %}
@@ -44,7 +44,7 @@
 
                         {# Last fieldset gets actions appended to it if actions_postion equals bottom. #}
                         {% if forloop.last and actions_position == 'auto' %}
-                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form=id %}
+                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form_id=id %}
                         {% endif %}
                     </fieldset>
 
@@ -52,7 +52,7 @@
                     {% if forloop.last and actions_position in 'bottom,both' %}
                         <br>
                         <div class="form__body">
-                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form=id %}
+                            {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form_id=id %}
                         </div>
                     {% endif %}
                 {% endfor %}
@@ -63,7 +63,7 @@
                         {% form_field field %}
                     {% endfor %}
 
-                    {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form=id %}
+                    {% include 'rijkshuisstijl/components/form/actions.html' with align=actions_align button_class=button_class label=label form_id=id %}
                 </fieldset>
             {% endif %}
         </div>

--- a/rijkshuisstijl/templates/rijkshuisstijl/components/key-value-table/key-value-table.html
+++ b/rijkshuisstijl/templates/rijkshuisstijl/components/key-value-table/key-value-table.html
@@ -43,7 +43,7 @@
                         <tr class="key-value-table__row key-value-table__row--actions">
                             <td class="key-value-table__key"></td>
                             <td class="key-value-table__value">
-                                {% button class='button--small button--primary' type="submit" label=_('Opslaan') %}
+                                {% button class='button--small button--primary' type="submit" label=_('Opslaan') form=form_id %}
                             </td>
                         </tr>
                     {% endif %}


### PR DESCRIPTION
Currently all inputs get the form attribute set except the submit buttons. This causes the form to submit to the form where the submit button resides. This PR sets the form attribute according to the given form id.