### PR TITLE
Add show_breadcrumbs flag

### DIFF
--- a/rijkshuisstijl/templates/rijkshuisstijl/components/navigation-bar/navigation-bar.html
+++ b/rijkshuisstijl/templates/rijkshuisstijl/components/navigation-bar/navigation-bar.html
@@ -11,5 +11,8 @@
             {% endif %}
         </div>
     </nav>
-    {% sitetree_breadcrumbs from "navigation-bar" template 'rijkshuisstijl/components/navigation-bar/breadcrumbs.html' %}
+
+    {% if show_breadcrumbs %}
+        {% sitetree_breadcrumbs from "navigation-bar" template 'rijkshuisstijl/components/navigation-bar/breadcrumbs.html' %}
+    {% endif %}
 {% endspaceless %}

--- a/rijkshuisstijl/templatetags/rijkshuisstijl_layout.py
+++ b/rijkshuisstijl/templatetags/rijkshuisstijl_layout.py
@@ -417,6 +417,7 @@ def navigation_bar(context, **kwargs):
         - search_placeholder: Optional, alternative label to show as search input placeholder.
         - search_method: Optional, The method to use for the search form.
         - search_name: Optional, The method to use for the search input.
+        - show_breadcrumbs: Optional, If True (default) breadcrumbs will be shown.
 
 
     :param context:
@@ -445,6 +446,8 @@ def navigation_bar(context, **kwargs):
     kwargs["search_placeholder"] = kwargs.get("search_placeholder", _("Zoeken"))
     kwargs["search_method"] = kwargs.get("search_method", "get")
     kwargs["search_name"] = kwargs.get("search_name", "q")
+
+    kwargs["show_breadcrumbs"] = kwargs.get("show_breadcrumbs", True)
 
     kwargs["request"] = context["request"]
     kwargs["user"] = get_request_user(context["request"])

--- a/rijkshuisstijl/tests/templatetags/test_rijkshuisstijl_layout.py
+++ b/rijkshuisstijl/tests/templatetags/test_rijkshuisstijl_layout.py
@@ -1,0 +1,44 @@
+from django.template import Context, Template
+from django.test import RequestFactory, TestCase
+
+from rijkshuisstijl.tests.templatetags.utils import InclusionTagWebTest
+
+
+class NavigationBarTestCase(InclusionTagWebTest):
+    def test_navigation_bar(self):
+        config = Context({"request": RequestFactory().get("/foo")})
+        html = (
+            Template(
+                '{% load rijkshuisstijl %}{% block navigation %}{% navigation_bar %}{% endblock %}'
+            )
+            .render(config)
+        )
+
+        self.assertInHTML(
+            '<nav class="navigation-bar"><div class="navigation-bar__body">'
+            '<div class="login-bar"><p class="login-bar__body">'
+            '<a class="login-bar__link login-bar__link--primary" href="/accounts/login/">Inloggen</a>'
+            '</p></div><ul class="menu"></ul></div></nav>',
+            html,
+            count=1
+        )
+
+    def test_breadcrumb_override(self):
+        config = Context({"request": RequestFactory().get("/foo")})
+        html = (
+            Template(
+                '{% load rijkshuisstijl %}{% block navigation %}'
+                '{% navigation_bar show_breadcrumbs=False %}'
+                '<ul class="custom-breadcrumbs"><li>Item 1</li><li>Item 2</li></ul>{% endblock %}'
+            )
+            .render(config)
+        )
+
+        self.assertInHTML(
+            '<nav class="navigation-bar"><div class="navigation-bar__body">'
+            '<div class="login-bar"><p class="login-bar__body">'
+            '<a class="login-bar__link login-bar__link--primary" href="/accounts/login/">Inloggen</a>'
+            '</p></div><ul class="menu"></ul></div></nav><ul class="custom-breadcrumbs"><li>Item 1</li><li>Item 2</li></ul>',
+            html,
+            count=1
+        )


### PR DESCRIPTION
Adds the `show_breadcrumbs` flag to the `navigation_bar` component so that templates can override the `breadcrumb` component or use different HTML for it.