### PR TITLE
:sparkles: - Allow passing a custom QuerySet to a datagrid filter.

### DIFF
--- a/rijkshuisstijl/templatetags/rijkshuisstijl_datagrid.py
+++ b/rijkshuisstijl/templatetags/rijkshuisstijl_datagrid.py
@@ -384,16 +384,20 @@ def datagrid(context, **kwargs):
 
             # Filter one filter at a time.
             for active_filter in active_filters:
-                # Bypass filter if set.
-                if active_filter.get("bypass_filter", False):
-                    continue
-
                 lookup = active_filter.get("lookup")
                 filter_value = active_filter.get("value")
                 filter_type = active_filter.get("type")
 
+                # Bypass filter if set.
+                if active_filter.get("bypass_filter", False):
+                    continue
+
+                # "filter_queryset".
+                elif active_filter.get("filter_queryset"):
+                    filter_kwargs = {lookup: filter_value}
+
                 # Date.
-                if filter_type in ["DateField", "DateTimeField"]:  # TODO: DateTimeField
+                elif filter_type in ["DateField", "DateTimeField"]:  # TODO: DateTimeField
                     dates = re.split(r"[^\d-]+", filter_value)
 
                     if len(dates) == 1:
@@ -541,8 +545,12 @@ def datagrid(context, **kwargs):
                     # Default choices.
                     choices = getattr(filter_field, "choices", [])
 
+                    # Allow a "filter_queryset" to be set.
+                    if "filter_queryset" in filterable_column:
+                        choices = filterable_column.get("filter_queryset")
+
                     # A boolean field gets choices for the boolean values.
-                    if filterable_column.get("type") == "BooleanField":
+                    elif filterable_column.get("type") == "BooleanField":
                         choices = ((True, _("waar")), (False, _("onwaar")))
 
                     # A related field gets choices for all related objects. This can be slow if a lot of objects are found.

--- a/rijkshuisstijl/tests/templatetags/test_rijkshuisstijl_datagrid.py
+++ b/rijkshuisstijl/tests/templatetags/test_rijkshuisstijl_datagrid.py
@@ -2,9 +2,9 @@ from django.core.paginator import Paginator
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 
-from rijkshuisstijl.tests.templatetags.utils import InclusionTagWebTest
-from rijkshuisstijl.tests.models import Author, Book, Publisher
 from rijkshuisstijl.tests.factories import AuthorFactory, BookFactory, PublisherFactory
+from rijkshuisstijl.tests.models import Author, Book, Publisher
+from rijkshuisstijl.tests.templatetags.utils import InclusionTagWebTest
 
 
 class DatagridTestCase(InclusionTagWebTest):
@@ -139,6 +139,25 @@ class DatagridTestCase(InclusionTagWebTest):
         self.assertTextContent(
             ".datagrid__table-body .datagrid__cell:first-child", self.book_2.title, config, data
         )
+
+    def test_filter_filter_queryset(self):
+        config = {
+            "columns": ("title", {"key": "publisher"}),
+            "queryset": Book.objects.all(),
+            "filterable_columns": [{
+                "key": "publisher",
+                "filter_queryset": Publisher.objects.filter(name=self.publisher_1.name),
+            }]
+        }
+        publisher_options = self.select("[name=\"publisher\"] option", config)
+
+        self.assertEqual(len(publisher_options), 2)
+
+        self.assertEqual(publisher_options[0].text, "---------")
+        self.assertEqual(publisher_options[0]["value"], "")
+
+        self.assertEqual(publisher_options[1].text, self.publisher_1.name)
+        self.assertEqual(publisher_options[1]["value"], str(self.publisher_1.pk))
 
     def test_orderable_columns_list(self):
         """
@@ -626,8 +645,8 @@ class DatagridTestCase(InclusionTagWebTest):
             "form": True,
             "form_select": {"name": "My First Select"},
             "form_options": [
-                {"label": "Foo", "value": "Bar",},
-                {"label": "Lorem", "value": "Ipsum",},
+                {"label": "Foo", "value": "Bar", },
+                {"label": "Lorem", "value": "Ipsum", },
             ],
         }
 


### PR DESCRIPTION
```
        config = {
            "columns": ("title", {"key": "publisher"}),
            "queryset": Book.objects.all(),
            "filterable_columns": [{
                "key": "publisher",
                "filter_queryset": Publisher.objects.filter(name=self.publisher_1.name),
            }]
        }
```