### PR TITLE
Allow specifying urlize on a column basis

### DIFF
--- a/rijkshuisstijl/templates/rijkshuisstijl/components/datagrid/datagrid-row.html
+++ b/rijkshuisstijl/templates/rijkshuisstijl/components/datagrid/datagrid-row.html
@@ -20,7 +20,6 @@
         {% firstof label|linebreaksbr as label %}
     {% endif %}
 
-
     <td class="datagrid__cell{% if cell_input %} datagrid__cell--editable{% endif %}{% if column.key == modifier_column %} datagrid__cell--modifier{% endif %}">
         {% if forloop.counter0 == 0 and formset_form %}
             <input type="hidden" name="{{ formset_form.id.html_name }}" value="{{ formset_form.id.value|unlocalize }}" form="{{ 'datagrid-inline-form-'|add:id }}">
@@ -39,7 +38,7 @@
 
 
         {% else %}
-            {% if urlize %}
+            {% if urlize and not column.urlize == False %}
 
 
                 <span class="datagrid__label{% if formset_form %} toggle{% endif %}"{% if formset_form %} data-toggle-target="#{{ row_id }}" data-toggle-modifier="edit" data-toggle-link-mode="noprevent"{% endif %}>{{ label|rh_urlize }}</span>

--- a/rijkshuisstijl/templates/rijkshuisstijl/components/datagrid/datagrid-row.html
+++ b/rijkshuisstijl/templates/rijkshuisstijl/components/datagrid/datagrid-row.html
@@ -38,7 +38,7 @@
 
 
         {% else %}
-            {% if urlize and not column.urlize == False %}
+            {% if column.urlize or urlize and not column.urlize == False %}
 
 
                 <span class="datagrid__label{% if formset_form %} toggle{% endif %}"{% if formset_form %} data-toggle-target="#{{ row_id }}" data-toggle-modifier="edit" data-toggle-link-mode="noprevent"{% endif %}>{{ label|rh_urlize }}</span>

--- a/rijkshuisstijl/templatetags/rijkshuisstijl_datagrid.py
+++ b/rijkshuisstijl/templatetags/rijkshuisstijl_datagrid.py
@@ -61,7 +61,7 @@ def datagrid(context, **kwargs):
 
     - queryset: Optional, A queryset containing the objects to show.
 
-    - columns: Required, a dict ("key", "label"), a list_of_dict ("key", "lookup", "label", "width") or a list
+    - columns: Required, a dict ("key", "label"), a list_of_dict ("key", "lookup", "label", "width", "urlize") or a list
       defining which columns/values to show for each object in object_list or queryset.
 
       - If a dict is passed, each key will represent a field in an object to obtain the data from and each value
@@ -274,7 +274,7 @@ def datagrid(context, **kwargs):
     - url_reverse: Optional, A URL name to reverse using the object's 'pk' attribute as one and only attribute,
       creates hyperlinks in the first cell. If no url_reverse if passed get_absolute_url is tried in order to find
       a url.
-    - urlize: Optional, if True (default) cell values are passed to "urlize" template filter, automatically creating
+    - urlize: Optional, if True (default) cell values are passed to "urlize" template filter, automatically creating. Passing FQN urls to this filter will cause urlize to be ran twice which lead to unwanted behaviour, set urlize to False on a column basis to prevent this.
       hyperlinks if applicable in every cell.
 
     :param context:

--- a/rijkshuisstijl/tests/models.py
+++ b/rijkshuisstijl/tests/models.py
@@ -81,6 +81,9 @@ class Conference(models.Model):
 class Company(models.Model):
     name = models.CharField(max_length=255, default="Foo Bar Inc")
 
+    def get_absolute_url(self):
+        return "https://example.com"
+
     class Meta:
         verbose_name = "Firm"
 

--- a/rijkshuisstijl/tests/urls.py
+++ b/rijkshuisstijl/tests/urls.py
@@ -27,9 +27,14 @@ urlpatterns = [
         name="delete-multiple",
     ),
     path(
-        "publisher/<int:pk>",
+        "publishers/<int:pk>",
         DetailView.as_view(model=Publisher, fields=("name", "book_set",)),
         name="publisher-detail",
+    ),
+    path(
+        "publishers/",
+        ListView.as_view(model=Publisher),
+        name="publisher-list",
     ),
     path(
         "author/<int:pk>",

--- a/rijkshuisstijl/tests/views/test_generic.py
+++ b/rijkshuisstijl/tests/views/test_generic.py
@@ -473,6 +473,23 @@ class ListViewTestCase(ViewTestCaseMixin, TestCase):
         object_list = response.context_data.get("object_list")
         self.assertEqual(len(object_list), 0)
 
+    def test_urlize_override(self):
+        """
+        Tests that setting urlize on a column basis overrides datagrid's global urlize
+        """
+        self.view.columns = [{"key": "name"}, {"key": "company", "urlize": False}]
+
+        response = self.client_get(url_name="publisher-list")
+
+        companies = (self.publisher_1.company, self.publisher_2.company,)
+
+        for company in companies:
+            with self.subTest(company=company):
+                self.assertContains(
+                    response,
+                    f'<a class="link" href="{company.get_absolute_url()}">{company}</a>'
+                )
+
 
 class UpdateViewTestCase(ViewTestCaseMixin, FormTestCaseMixin, TestCase):
     url_name = "update"


### PR DESCRIPTION
When calling `rh_urlize` with an string which contains a valid html link already, an undesired return value will be returned, for example:

**Input value:**
```
<a class="link" href="https://www.foobar.nl/">Foobar</a>
```
**Return value:**
```
<a "="" class="link" href="&lt;a href=" https:="" rel="nofollow" www.foobar.nl="">https://www.foobar.nl/</a>"&gt
```

The "problem" here is that the `urlize` call will return a link inside a link if the `href` attribute contains a url with a protocol.