### PR TITLE
Reevaluete queryset whenever a filter option is a related field

### DIFF
--- a/rijkshuisstijl/templatetags/rijkshuisstijl_datagrid.py
+++ b/rijkshuisstijl/templatetags/rijkshuisstijl_datagrid.py
@@ -540,7 +540,7 @@ def datagrid(context, **kwargs):
                 filterable_column["type"] = type(filter_field).__name__
 
             # If not choices have been set, find them based on the field.
-            if not "choices" in filterable_column:
+            if not "choices" in filterable_column or "is_relation" in filterable_column:
                 try:
                     # Default choices.
                     choices = getattr(filter_field, "choices", [])


### PR DESCRIPTION
Voorheen werden de keuzes niet opnieuw berekend als deze eerder al berekend waren. Dit is handig voor niet-dynamische keuzes maar voor dynamische keuzes worden geen nieuwe keuzes ingeladen nadat deze de eerste keer berekend zijn.